### PR TITLE
Reposition the max node setting in the tutorial

### DIFF
--- a/docs/running-on-coclobas.md
+++ b/docs/running-on-coclobas.md
@@ -20,12 +20,11 @@ of them.
 You'll need the GCloud command line utility, installed and initialized
 [from here](https://cloud.google.com/sdk/downloads#interactive).
 
-Optionally set your preferred zone and cluster sizes before you get started:
+Optionally set your preferred zone before you get started:
 
 ```shell
-# disco.sh defaults
+# disco.sh default
 export GCLOUD_ZONE="us-east1-c"
-export CLUSTER_MAX_NODES=15
 ```
 
 Download our setup script and use it to create a GCloud box:
@@ -49,6 +48,10 @@ machine. Note that `disco.sh` should have been copied to your home directory on
 this box for you already.
 
 ```shell
+# Optional: change this if you need a bigger/smaller cluster
+export CLUSTER_MAX_NODES=15
+
+# Configure
 ./disco.sh configure
 ```
 

--- a/docs/running-on-coclobas.md
+++ b/docs/running-on-coclobas.md
@@ -51,6 +51,9 @@ this box for you already.
 # Optional: change this if you need a bigger/smaller cluster
 export CLUSTER_MAX_NODES=15
 
+# Change the following only if you changed the zone during the initial setup
+export GCLOUD_ZONE="us-east1-c"
+
 # Configure
 ./disco.sh configure
 ```


### PR DESCRIPTION
In the previous version, we were setting it too early and the config step was missing it falling back to the default all the time.
