### PR TITLE
add KETREW_CONFIGURATION to configuration.env

### DIFF
--- a/docs/disco.sh
+++ b/docs/disco.sh
@@ -125,6 +125,10 @@ export BIOKEPI_WORK_DIR=/nfs-pool/biokepi/
 ## Usual Biokepi variables used to download Broad software:
 # export GATK_JAR_URL="http://example.com/GATK.jar"
 # export MUTECT_JAR_URL="http://example.com/Mutect.jar"
+
+## Default ketrew configuration location
+export KETREW_CONFIGURATION=/coclo/_kclient_config/configuration.ml
+
 EOF
     echo "Created ./configuration.env"
 }


### PR DESCRIPTION
throughout my humble trials and errors in working with coclo/epidisco,
I found myself forgetting to set this up and almost always adding appending
this to the `configuration.env`. Assuming that _most_ people will be following
this tutorial and will only use the simplest setup, it might make sense to
make this default for convenience.

Just my two cents
