### PR TITLE
Force the use of Ketrew 3.0.0

### DIFF
--- a/docs/disco.sh
+++ b/docs/disco.sh
@@ -168,6 +168,8 @@ cluster-status () {
 }
 
 install-epidisco () {
+    opam pin add --yes ketrew 3.0.0
+    opam reinstall ketrew --yes
     opam pin add --yes biokepi "https://github.com/hammerlab/biokepi.git"
     opam pin add --yes epidisco "https://github.com/hammerlab/epidisco.git"
 }


### PR DESCRIPTION
It is a bit wasteful to got through `reinstall` but it's the easiest path.
