### PR TITLE
Split up the command line arguments

### DIFF
--- a/src/lib/command_line.ml
+++ b/src/lib/command_line.ml
@@ -1,4 +1,3 @@
-
 open Nonstd
 module String = Sosa.Native_string
 let (//) = Filename.concat
@@ -6,11 +5,13 @@ let or_fail msg = function
 | `Ok o -> o
 | `Error s -> ksprintf failwith "%s: %s" msg s
 
+
 let cmdf fmt =
   ksprintf (fun s ->
       match Sys.command s with
       | 0 -> ()
       | n -> ksprintf failwith "CMD failed: %s → %d" s n) fmt
+
 
 let output_dot sm ~dot ~png =
   try
@@ -21,6 +22,7 @@ let output_dot sm ~dot ~png =
     cmdf "dot -v -x -Tpng  %s -o %s > %s 2>&1" dot png dotlog;
   with e ->
     eprintf "ERROR outputing DOT: %s\n%!" (Printexc.to_string e)
+
 
 let run_pipeline
     ?(dry_run = false)
@@ -99,23 +101,7 @@ let run_pipeline
   end
 
 
-let pipeline_term
-    ~biokepi_machine ?work_directory () =
-  let open Cmdliner in
-  let json_file_arg ?(req = true) option_name f =
-    let doc = sprintf "JSON file describing the %S sample" option_name in
-    let inf = Arg.info [option_name] ~doc ~docv:"PATH" in
-    Term.(
-      pure f
-      $
-      Arg.(
-        (if req
-         then required & opt (some string) None & inf
-         else value & opt string "" & inf)
-      )
-    )
-  in
-  let info = Term.(info "pipeline" ~doc:"The Epidisco Pipeline") in
+let pipeline ~biokepi_machine ?work_directory =
   let parse_input_file file ~kind =
     match Filename.check_suffix file ".bam" with
     | true ->
@@ -128,201 +114,227 @@ let pipeline_term
     | false ->
       Yojson.Safe.from_file file
       |> Biokepi.EDSL.Library.Input.of_yojson |> or_fail (kind ^ "-json") in
-  let term =
-    Term.(
-      let tool_option f name =
-        pure f
-        $ Arg.(
-            value & flag & info [sprintf "with-%s" name]
-              ~doc:(sprintf "Also run `%s`" name)
-          ) in
-      let bed_file_opt =
-        Term.(pure (fun e -> `Bedfile e)
-              $ Arg.(
-                  let doc =
-                    "Run bedtools intersect on VCFs with the given bed file. \
-                     file://... or http(s)://..." in
-                  value
-                  & opt (some string) None
-                  & info ["filter-vcfs-to-region-with"] ~doc))
+  fun
+    (`Dry_run dry_run)
+    (`Mouse_run mouse_run)
+    (`With_seq2hla with_seq2hla)
+    (`With_optitype_normal with_optitype_normal)
+    (`With_optitype_tumor with_optitype_tumor)
+    (`With_optitype_rna with_optitype_rna)
+    (`With_mutect2 with_mutect2)
+    (`With_varscan with_varscan)
+    (`With_somaticsniper with_somaticsniper)
+    (`Bedfile bedfile)
+    (`Normal_json normal_json_file)
+    (`Tumor_json tumor_json_file)
+    (`Rna_json rna_json_file)
+    (`Ref reference_build)
+    (`Results results_path)
+    (`Output_dot output_dot_to_png)
+    (`Mhc_alleles mhc_alleles)
+    (`Picard_java_max_heap picard_java_max_heap)
+    (`Experiment_name experiment_name)
+    (`Mailgun_api_key mailgun_api_key)
+    (`Mailgun_domain mailgun_domain_name)
+    (`From_email from_email)
+    (`To_email to_email)
+    (`Igv_url_server_prefix igv_url_server_prefix)
+    ->
+      let normal = parse_input_file normal_json_file ~kind:"normal" in
+      let tumor = parse_input_file tumor_json_file ~kind:"tumor" in
+      let rna =
+        match rna_json_file with
+        | "" ->
+          eprintf "WARNING: No RNA provided\n%!";
+          None
+        | file ->
+          Some (parse_input_file file ~kind:"rna")
       in
-      pure begin fun
-        (`Dry_run dry_run)
-        (`Mouse_run mouse_run)
-        (`With_seq2hla with_seq2hla)
-        (`With_optitype_normal with_optitype_normal)
-        (`With_optitype_tumor with_optitype_tumor)
-        (`With_optitype_rna with_optitype_rna)
-        (`With_mutect2 with_mutect2)
-        (`With_varscan with_varscan)
-        (`With_somaticsniper with_somaticsniper)
-        (`Bedfile bedfile)
-        (`Normal_json normal_json_file)
-        (`Tumor_json tumor_json_file)
-        (`Rna_json rna_json_file)
-        (`Ref reference_build)
-        (`Results results_path)
-        (`Output_dot output_dot_to_png)
-        (`Mhc_alleles mhc_alleles)
-        (`Picard_java_max_heap picard_java_max_heap)
-        (`Experiment_name experiment_name)
-        (`Mailgun_api_key mailgun_api_key)
-        (`Mailgun_domain mailgun_domain_name)
-        (`From_email from_email)
-        (`To_email to_email)
-        ->
-          let normal = parse_input_file normal_json_file ~kind:"normal" in
-          let tumor = parse_input_file tumor_json_file ~kind:"tumor" in
-          let rna =
-            match rna_json_file with
-            | "" ->
-              eprintf "WARNING: No RNA provided\n%!";
-              None
-            | file ->
-              Some (parse_input_file file ~kind:"rna")
-          in
-          let email_options =
-            match
-              to_email, from_email, mailgun_domain_name, mailgun_api_key with
-            | Some to_email, Some from_email,
-              Some mailgun_domain_name, Some mailgun_api_key ->
-              Some (Qc.EDSL.make_email_options
-                        ~from_email ~to_email
-                        ~mailgun_api_key ~mailgun_domain_name)
-            | None, None, None, None -> None
-            | _, _, _, _ ->
-              failwith "ERROR: If one of `to-email`, `from-email`, \
-                        `mailgun-api-key`, `mailgun-domain-name` \
-                        are specified, then they all must be."
-          in
-          let params =
-            Pipeline.Parameters.make experiment_name
-              ~bedfile ~mouse_run
-              ~reference_build ~normal ~tumor ?rna
-              ?mhc_alleles
-              ?email_options
-              ~with_seq2hla
-              ~with_optitype_normal
-              ~with_optitype_tumor
-              ~with_optitype_rna
-              ~with_mutect2
-              ~with_varscan
-              ~with_somaticsniper
-              ?picard_java_max_heap
-          in
-          run_pipeline ~biokepi_machine ~results_path ?work_directory
-            ~dry_run params
-            ?output_dot_to_png
-      end
-      $ begin
-        pure (fun b -> `Dry_run b)
-        $ Arg.(
-            value & flag & info ["dry-run"] ~doc:"Dry-run; do not submit"
-          )
-      end
-      $ begin
-        pure (fun b -> `Mouse_run b)
-        $ Arg.(
-            value & flag & info ["mouse-run"]
-              ~doc:"Mouse-run; use mouse-specific config (no COSMIC)"
-          )
-      end
-      $ tool_option (fun e -> `With_seq2hla e) "seq2hla"
-      $ tool_option (fun e -> `With_optitype_normal e) "optitype-normal"
-      $ tool_option (fun e -> `With_optitype_tumor e) "optitype-tumor"
-      $ tool_option (fun e -> `With_optitype_rna e) "optitype-rna"
-      $ tool_option (fun e -> `With_mutect2 e) "mutect2"
-      $ tool_option (fun e -> `With_varscan e) "varscan"
-      $ tool_option (fun e -> `With_somaticsniper e) "somaticsniper"
-      $ bed_file_opt
-      $ json_file_arg "normal" (fun s -> `Normal_json s)
-      $ json_file_arg "tumor" (fun s -> `Tumor_json s)
-      $ json_file_arg ~req:false "rna" (fun s -> `Rna_json s)
-      $ begin
-        pure (fun s -> `Ref s)
-        $ Arg.(
-            required & opt (some string) None
-            & info ["reference-build"; "R"]
-              ~doc:"The reference-build" ~docv:"NAME")
-      end
-      $ begin
-        pure (fun s -> `Results s)
-        $ Arg.(
-            required & opt (some string) None
-            & info ["results-path"]
-              ~doc:"Where to save the results" ~docv:"NAME")
-      end
-      $ begin
-        pure (fun s -> `Output_dot s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["dot-png"]
-              ~doc:"Output the pipeline as a PNG file" ~docv:"PATH")
-      end
-      $ begin
-        pure (fun s -> `Mhc_alleles s)
-        $ Arg.(
-            value & opt (list ~sep:',' string |> some) None
-            & info ["mhc-alleles"]
-              ~doc:"Run pipeline with the given list of MHC alleles \
-                    in lieu of those generated by Seq2Hla or OptiType: $(docv)"
-              ~docv:"LIST")
-      end
-      $ begin
-        pure (fun s -> `Picard_java_max_heap s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["picard-java-max-heap-size"]
-              ~doc:"Max Java heap size used for Picard Mark Dups \
-                   e.g. 8g, 256m.")
-      end
-      $ begin
-        pure (fun s -> `Experiment_name s)
-        $ Arg.(
-            required & opt (some string) None
-            & info ["experiment-name"; "E"]
-              ~doc:"Give a name to the run(s)" ~docv:"NAME")
-      end
-      $ begin
-        pure (fun s -> `Mailgun_api_key s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["mailgun-api-key"]
-              ~doc:"Mailgun API key, used for notification emails."
-              ~docv:"MAILGUN_API_KEY")
-      end
-      $ begin
-        pure (fun s -> `Mailgun_domain s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["mailgun-domain"]
-              ~doc:"Mailgun domain, used for notification emails."
-              ~docv:"MAILGUN_DOMAIN")
-      end
-      $ begin
-        pure (fun s -> `From_email s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["from-email"]
-              ~doc:"Email address used for notification emails."
-              ~docv:"FROM_EMAIL")
-      end
-      $ begin
-        pure (fun s -> `To_email s)
-        $ Arg.(
-            value & opt (some string) None
-            & info ["to-email"]
-              ~doc:"Email address to send notification emails to."
-              ~docv:"TO_EMAIL")
-      end
-    ) in
+      let email_options =
+        match
+          to_email, from_email, mailgun_domain_name, mailgun_api_key with
+        | Some to_email, Some from_email,
+          Some mailgun_domain_name, Some mailgun_api_key ->
+          Some (Qc.EDSL.make_email_options
+                  ~from_email ~to_email
+                  ~mailgun_api_key ~mailgun_domain_name)
+        | None, None, None, None -> None
+        | _, _, _, _ ->
+          failwith "ERROR: If one of `to-email`, `from-email`, \
+                    `mailgun-api-key`, `mailgun-domain-name` \
+                    are specified, then they all must be."
+      in
+      let params =
+        Pipeline.Parameters.make experiment_name
+          ~normal ~tumor ?rna
+          ~bedfile
+          ~mouse_run
+          ~reference_build
+          ?mhc_alleles
+          ?email_options
+          ~with_seq2hla
+          ~with_optitype_normal
+          ~with_optitype_tumor
+          ~with_optitype_rna
+          ~with_mutect2
+          ~with_varscan
+          ~with_somaticsniper
+          ?picard_java_max_heap
+          ?igv_url_server_prefix
+      in
+      run_pipeline ~biokepi_machine ~results_path ?work_directory
+        ~dry_run params
+        ?output_dot_to_png
+
+
+let args pipeline =
+  let open Cmdliner in
+  let open Cmdliner.Term in
+  let json_file_arg ?(req = true) option_name f =
+    let doc = sprintf "JSON file describing the %S sample" option_name in
+    let inf = Arg.info [option_name] ~doc ~docv:"PATH" in
+    pure f
+    $
+    Arg.(
+      (if req
+       then required & opt (some string) None & inf
+       else value & opt string "" & inf))
+  in
+  let tool_option f name =
+    pure f
+    $ Arg.(
+        value & flag & info [sprintf "with-%s" name]
+          ~doc:(sprintf "Also run `%s`" name)
+      ) in
+  let bed_file_opt =
+    pure (fun e -> `Bedfile e)
+    $ Arg.(
+        let doc =
+          "Run bedtools intersect on VCFs with the given bed file. \
+           file://... or http(s)://..." in
+        value
+        & opt (some string) None
+        & info ["filter-vcfs-to-region-with"] ~doc) in
+  app pipeline begin
+    pure (fun b -> `Dry_run b)
+    $ Arg.(value & flag & info ["dry-run"] ~doc:"Dry-run; do not submit")
+  end
+  $ begin
+    pure (fun b -> `Mouse_run b)
+    $ Arg.(
+        value & flag & info ["mouse-run"]
+          ~doc:"Mouse-run; use mouse-specific config (no COSMIC)"
+      )
+  end
+  $ tool_option (fun e -> `With_seq2hla e) "seq2hla"
+  $ tool_option (fun e -> `With_optitype_normal e) "optitype-normal"
+  $ tool_option (fun e -> `With_optitype_tumor e) "optitype-tumor"
+  $ tool_option (fun e -> `With_optitype_rna e) "optitype-rna"
+  $ tool_option (fun e -> `With_mutect2 e) "mutect2"
+  $ tool_option (fun e -> `With_varscan e) "varscan"
+  $ tool_option (fun e -> `With_somaticsniper e) "somaticsniper"
+  $ bed_file_opt
+  $ json_file_arg "normal" (fun s -> `Normal_json s)
+  $ json_file_arg "tumor" (fun s -> `Tumor_json s)
+  $ json_file_arg ~req:false "rna" (fun s -> `Rna_json s)
+  $ begin
+    pure (fun s -> `Ref s)
+    $ Arg.(
+        required & opt (some string) None
+        & info ["reference-build"; "R"]
+          ~doc:"The reference-build" ~docv:"NAME")
+  end
+  $ begin
+    pure (fun s -> `Results s)
+    $ Arg.(
+        required & opt (some string) None
+        & info ["results-path"]
+          ~doc:"Where to save the results" ~docv:"NAME")
+  end
+  $ begin
+    pure (fun s -> `Output_dot s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["dot-png"]
+          ~doc:"Output the pipeline as a PNG file" ~docv:"PATH")
+  end
+  $ begin
+    pure (fun s -> `Mhc_alleles s)
+    $ Arg.(
+        value & opt (list ~sep:',' string |> some) None
+        & info ["mhc-alleles"]
+          ~doc:"Run pipeline with the given list of MHC alleles \
+                in lieu of those generated by Seq2Hla or OptiType: $(docv)"
+          ~docv:"LIST")
+  end
+  $ begin
+    pure (fun s -> `Picard_java_max_heap s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["picard-java-max-heap-size"]
+          ~doc:"Max Java heap size used for Picard Mark Dups \
+                e.g. 8g, 256m.")
+  end
+  $ begin
+    pure (fun s -> `Experiment_name s)
+    $ Arg.(
+        required & opt (some string) None
+        & info ["experiment-name"; "E"]
+          ~doc:"Give a name to the run(s)" ~docv:"NAME")
+  end
+  $ begin
+    pure (fun s -> `Mailgun_api_key s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["mailgun-api-key"]
+          ~doc:"Mailgun API key, used for notification emails."
+          ~docv:"MAILGUN_API_KEY")
+  end
+  $ begin
+    pure (fun s -> `Mailgun_domain s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["mailgun-domain"]
+          ~doc:"Mailgun domain, used for notification emails."
+          ~docv:"MAILGUN_DOMAIN")
+  end
+  $ begin
+    pure (fun s -> `From_email s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["from-email"]
+          ~doc:"Email address used for notification emails."
+          ~docv:"FROM_EMAIL")
+  end
+  $ begin
+    pure (fun s -> `To_email s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["to-email"]
+          ~doc:"Email address to send notification emails to."
+          ~docv:"TO_EMAIL")
+  end
+  $ begin
+    pure (fun s -> `Igv_url_server_prefix s)
+    $ Arg.(
+        value & opt (some string) None
+        & info ["igv-url-server-prefix"]
+          ~doc:"URL with which to prefix IGV.xml paths."
+          ~docv:"IGV_URL_SERVER_PREFIX")
+  end
+
+
+let pipeline_term ~biokepi_machine ?work_directory () =
+  let open Cmdliner in
+  let info = Term.(info "pipeline" ~doc:"The Epidisco Pipeline") in
+  let term = Term.(pure (pipeline ~biokepi_machine ?work_directory)) |> args in
   (term, info)
+
 
 let main
     ~biokepi_machine ?work_directory () =
   let version = Metadata.version |> Lazy.force in
-  let pipe =
-    pipeline_term ~biokepi_machine ?work_directory () in
+  let pipe = pipeline_term ~biokepi_machine ?work_directory () in
   let open Cmdliner in
   let default_cmd =
     let doc = "Run the Epidisco pipeline." in

--- a/src/lib/extended_edsl.ml
+++ b/src/lib/extended_edsl.ml
@@ -72,6 +72,7 @@ module Apply_functions (B : Semantics) = struct
     fwd email
 
   let report
+      ?igv_url_server_prefix
       ~vcfs
       ~fastqc_normal
       ~fastqc_tumor
@@ -114,5 +115,6 @@ module Apply_functions (B : Semantics) = struct
            ?seq2hla:(Option.map seq2hla bwd)
            ?stringtie:(Option.map stringtie bwd)
            ?bedfile
+           ?igv_url_server_prefix
            ~metadata)
 end

--- a/src/lib/pipeline.ml
+++ b/src/lib/pipeline.ml
@@ -86,6 +86,7 @@ module Parameters = struct
     tumor: Biokepi.EDSL.Library.Input.t;
     rna: Biokepi.EDSL.Library.Input.t option;
     picard_java_max_heap: string option;
+    igv_url_server_prefix: string option;
   } [@@deriving show,make]
 
   let construct_run_name params =
@@ -359,6 +360,7 @@ module Full (Bfx: Extended_edsl.Semantics) = struct
     let report =
       Bfx.report
         (Parameters.construct_run_name parameters)
+        ?igv_url_server_prefix:parameters.igv_url_server_prefix
         ~vcfs:maybe_annotated ?bedfile
         ~fastqc_normal ~fastqc_tumor ?fastqc_rna
         ~normal_bam ~tumor_bam ?rna_bam


### PR DESCRIPTION
Also add an option for a prefix to be passed for all IGV resources in
the IGV.xml file created. This is used to make the relative paths in the
final results directory absolute.