### PR TITLE
fix how we save optitype results

### DIFF
--- a/src/lib/save_result.ml
+++ b/src/lib/save_result.ml
@@ -203,7 +203,7 @@ module To_workflow
       ]
     | Optitype_result wf ->
       Mem.add_to_save key [
-        saved wf#product#path wf;
+        saved ~is_directory:true wf#product#path wf;
       ]
     | Vaxrank_result wf ->
       Mem.add_to_save key [


### PR DESCRIPTION
Apparently, I forgot the directory flag and the `Saved: Optitype` workflow was failing on me :\
