### PR TITLE
Make sure JSON description files don't have too long names

### DIFF
--- a/src/lib/save_result.ml
+++ b/src/lib/save_result.ml
@@ -2,6 +2,7 @@
 open Nonstd
 module String = Sosa.Native_string
 let (//) = Filename.concat
+module Name_file = Biokepi_run_environment.Common.Name_file
 
 module type Semantics = sig
 
@@ -28,7 +29,7 @@ let construct_relative_path ~work_dir original_path =
     ksprintf failwith "ERROR: %s is not a prefix of %s"
       work_dir original_path
 
-let json_dump_path path = path ^ ".json"
+let json_dump_path path = Name_file.from_path ".json" path []
 
 let make_saving_node
     ~saving_path ~json_pipeline ~key ~run_with ~work_dir


### PR DESCRIPTION
I had cases where the length of the original data file (e.g. `flagstat`) name was borderline long and appending the `.json` suffix was causing it to be longer than the file system limits, therefore failing the `Saved: ...` job for that particular result.

This changeset adds control over the length of the JSON filename to avoid such cases.