### PR TITLE
Force gzip overwrite files when saving results

### DIFF
--- a/src/lib/save_result.ml
+++ b/src/lib/save_result.ml
@@ -55,7 +55,7 @@ let make_saving_node
             (Filename.quote path)
             (Filename.quote copied_path);
           optional gzip [
-            shf "gzip --keep %s" (Filename.quote copied_path);
+            shf "gzip --force --keep %s" (Filename.quote copied_path);
           ];
           shf "echo %s > %s"
             (Yojson.Basic.pretty_to_string json |> Filename.quote)


### PR DESCRIPTION
#87 led to a weird condition for gzip'ed results: when we have results folder containing partial results (gzip files) but not the JSON dumps (due to the recent name change), the save-node fails as it tries to overwrite the gzip files and fails to do so. This makes sure that gzip never prompts for such overwrites.