### PR TITLE
Use different names for nodes saving sample BAM and BAIs

### DIFF
--- a/src/lib/final_report.ml
+++ b/src/lib/final_report.ml
@@ -355,9 +355,10 @@ module To_workflow
                 let run_with = machine in
                 let gzip = s#gzip in
                 let is_directory = s#is_directory in
+                let name = s#name in
                 Save_result.make_saving_node
                   ~saving_path ~json_pipeline ~key ~run_with ~work_dir
-                  ~gzip ~is_directory s#edge s#path
+                  ~gzip ~is_directory ~name s#edge s#path
                 |> depends_on
               )
           )
@@ -427,7 +428,7 @@ module To_workflow
               (get_optitype_result i)#product#path);
           "Vaxrank",
           Option.map vaxrank ~f:(fun i ->
-              (get_vaxrank_result i)#product#text_report_path);
+              (get_vaxrank_result i)#product#output_folder_path);
           "Topiary",
           Option.map topiary ~f:(fun i ->
               (get_topiary_result i)#product#path);


### PR DESCRIPTION
Resolves #107 (adds support for using different names for multiple save nodes saved under a single key)

[![better node naming](https://cl.ly/3r36121Y402b/Image%202016-12-11%20at%2011.19.09%20PM.png)](https://cl.ly/3r36121Y402b/Image%202016-12-11%20at%2011.19.09%20PM.png)