### PR TITLE
Use Ketrew 3.0.0 by default

### DIFF
--- a/docs/disco.sh
+++ b/docs/disco.sh
@@ -139,7 +139,7 @@ setup-docker () {
     local path="`( cd \"$path\" && pwd )`"
     local script="$path/${0##*/}"
     apt-get install -y docker.io
-    docker pull hammerlab/coclobas
+    docker pull hammerlab/coclobas:with-ketrew-300
     mkdir -p /tmp/coclo
     chmod 777 /tmp/coclo
     cp configuration.env /tmp/coclo
@@ -156,7 +156,7 @@ enter-docker () {
     echo "cd to /coclo to get access to your config and disco.sh"
     echo "...entering the Docker!"
     docker run -it -p 443:443 -v /tmp/coclo:/coclo \
-           --privileged hammerlab/coclobas bash
+           --privileged hammerlab/coclobas:with-ketrew-300 bash
 }
 
 ###########################

--- a/docs/disco.sh
+++ b/docs/disco.sh
@@ -168,8 +168,6 @@ cluster-status () {
 }
 
 install-epidisco () {
-    opam pin add --yes ketrew 3.0.0
-    opam reinstall ketrew --yes
     opam pin add --yes biokepi "https://github.com/hammerlab/biokepi.git"
     opam pin add --yes epidisco "https://github.com/hammerlab/epidisco.git"
 }


### PR DESCRIPTION
This fixes #71 and is related to #121; the idea is that now there are Ketrew and
Biokepi branches (hence, Docker hub “tags”) that are well in sync.

Cf.:

- <https://hub.docker.com/r/hammerlab/biokepi-run/builds/>, tag  `docker-ketrew-300`, and
- <https://hub.docker.com/r/hammerlab/coclobas/builds/>, tag  `with-ketrew-300`.

I did one full run through the instructions with this `disco.sh` and all worked without any additional `opam pin`:

    $ ketrew --version
    3.0.0