### PR TITLE
Force setup-epidisco overwrite the old biokepi_machine.ml

### DIFF
--- a/docs/disco.sh
+++ b/docs/disco.sh
@@ -282,7 +282,7 @@ EOF
 setup-epidisco () {
     install-epidisco
     create-pipeline-script
-    wget https://raw.githubusercontent.com/hammerlab/coclobas/master/tools/docker/biokepi_machine.ml
+    wget -O /coclo/biokepi_machine.ml https://raw.githubusercontent.com/hammerlab/coclobas/master/tools/docker/biokepi_machine.ml
     source configuration.env
     # EXTERNAL_IP and TOKEN both come from configuration.env
     ketrew init --conf ./_kclient_config/ --just-client https://$EXTERNAL_IP/gui?token=$TOKEN


### PR DESCRIPTION
Without this, every setup attempt creates yet another `biokepi_machine.ml.N` in the `/coclo` directory, which doesn't cause any immediate issues but populates the directory and can sometimes lead to confusion (cc: @tavinathanson).

This will force wget to overwrite the machine description when downloading the new one and hence will help keep the folder clean.